### PR TITLE
fix: use ghcr.io/aquasecurity/trivy instead of deprecated aquasec/trivy

### DIFF
--- a/src/io/stenic/jpipe/plugin/TrivyPlugin.groovy
+++ b/src/io/stenic/jpipe/plugin/TrivyPlugin.groovy
@@ -60,7 +60,7 @@ class TrivyPlugin extends Plugin {
                     docker run \
                         -v /var/run/docker.sock:/var/run/docker.sock \
                         -v \$(pwd)/.trivy-report-${imgName}:/report \
-                        aquasec/trivy:${this.trivyVersion} \
+                        ghcr.io/aquasecurity/trivy:${this.trivyVersion} \
                         image ${args.join(' ')} ${this.containerImage}:${event.version}
                 """
             } catch (Exception e) {


### PR DESCRIPTION
## Summary

The `aquasec/trivy` Docker Hub image has been removed/deprecated. Trivy is now published at `ghcr.io/aquasecurity/trivy`.

This fixes the container scan step failing with:
```
docker: Error response from daemon: manifest for aquasec/trivy:latest not found: manifest unknown: manifest unknown.
```

## Changes

- Updated the Trivy Docker image reference in `TrivyPlugin.groovy` from `aquasec/trivy` to `ghcr.io/aquasecurity/trivy`