### PR TITLE
feat: emit SKIPPED event from SkipCommitPlugin

### DIFF
--- a/src/io/stenic/jpipe/event/Event.groovy
+++ b/src/io/stenic/jpipe/event/Event.groovy
@@ -6,6 +6,7 @@ class Event implements Serializable {
     public static final String TEST = "Test";
     public static final String PUBLISH = "Publish";
     public static final String DEPLOY = "Deploy";
+    public static final String SKIPPED = "Skipped";
 
     public String version;
     public def env;
@@ -14,4 +15,15 @@ class Event implements Serializable {
     public setScript(script) {
         this.script = script;
     }
+
+    // Optional dispatcher reference so plugins can publish follow-up events
+    // (e.g. SkipCommitPlugin emitting SKIPPED before aborting the build).
+    // Set by Pipeline.run() before dispatching.
+    public EventDispatcher eventDispatcher;
+    public setEventDispatcher(EventDispatcher eventDispatcher) {
+        this.eventDispatcher = eventDispatcher;
+    }
+
+    // Free-form payload for event-specific data (e.g. SKIPPED carries 'reason').
+    public Map data = [:];
 }

--- a/src/io/stenic/jpipe/pipeline/Pipeline.groovy
+++ b/src/io/stenic/jpipe/pipeline/Pipeline.groovy
@@ -25,6 +25,7 @@ class Pipeline implements Serializable {
         event.env = env;
         event.version = env.BUILD_ID;
         event.setScript(this.script)
+        event.setEventDispatcher(this.eventDispatcher)
 
         this.script.stage("Prepare") {
             this.eventDispatcher.dispatch("Prepare", event)

--- a/src/io/stenic/jpipe/plugin/SkipCommitPlugin.groovy
+++ b/src/io/stenic/jpipe/plugin/SkipCommitPlugin.groovy
@@ -28,6 +28,12 @@ class SkipCommitPlugin extends Plugin {
             }
             event.script.currentBuild.description = 'Skipped by [skip ci]'
 
+            // Notify subscribers (e.g. SCM status notifiers) that this build is being
+            // skipped, so they can publish a terminal commit status before we abort.
+            // SkipCommitPlugin stays SCM-agnostic; concrete notifiers live in user code.
+            event.data.reason = 'Skipped by [skip ci]'
+            event.eventDispatcher?.dispatch(Event.SKIPPED, event)
+
             // try {
             //     // Try doing a cleanup, required the following methods being approved.
             //     // method hudson.model.Run delete

--- a/test/io/stenic/jpipe/event/EventSpec.groovy
+++ b/test/io/stenic/jpipe/event/EventSpec.groovy
@@ -1,0 +1,38 @@
+
+import spock.lang.Specification
+import io.stenic.jpipe.event.Event
+import io.stenic.jpipe.event.EventDispatcher
+
+class EventSpec extends Specification {
+
+    def "[Event] exposes SKIPPED constant"() {
+        expect:
+            assert Event.SKIPPED == "Skipped"
+    }
+
+    def "[Event] carries dispatcher so plugins can publish follow-up events"() {
+        given:
+            def dispatcher = new EventDispatcher()
+            def received = []
+            dispatcher.addListener(Event.SKIPPED, { e -> received << e.data.reason }, 0)
+
+            def event = new Event()
+            event.setEventDispatcher(dispatcher)
+
+        when:
+            event.data.reason = 'Skipped by [skip ci]'
+            event.eventDispatcher.dispatch(Event.SKIPPED, event)
+
+        then:
+            assert received == ['Skipped by [skip ci]']
+    }
+
+    def "[Event] dispatcher reference is optional (null-safe)"() {
+        given:
+            def event = new Event()
+
+        expect:
+            // Plugins should null-check before dispatch; verify the field defaults to null.
+            assert event.eventDispatcher == null
+    }
+}


### PR DESCRIPTION
## Why

When `SkipCommitPlugin` matches `[skip ci]` it throws `FlowInterruptedException` to abort the build. That bypasses normal post-build hooks, so any external SCM status notifier (e.g. Jenkins' GitHub Branch Source plugin) never gets to publish a terminal status — the "Pending" status it posted on commit indexing stays Pending forever. This is especially visible with `semantic-release-bot` commits.

## What

- `Event`: new `SKIPPED` constant, optional `eventDispatcher` reference, and a free-form `data` map for event payloads.
- `Pipeline.run`: wires the dispatcher onto the event before dispatching.
- `SkipCommitPlugin`: emits `SKIPPED` with `data.reason` immediately before throwing `FlowInterruptedException`.

The plugin stays SCM-agnostic. Concrete notifiers (GitHub, GitLab, …) live in user code and just subscribe to `Event.SKIPPED`.

## Tests

Added `EventSpec` covering the constant, the dispatch wiring, and null-safety of the optional dispatcher reference. Note: the existing `make test` is currently broken upstream of this change (Maven rejects the Jenkins repo's HTTP→HTTPS redirect), unrelated to this PR.