### PR TITLE
fix: don't attach UserInterruption with null user id on [skip ci] abort

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <repository>
             <id>jenkins-releases</id>
             <name>Jenkins Releases</name>
-            <url>http://repo.jenkins-ci.org/releases</url>
+            <url>https://repo.jenkins-ci.org/releases</url>
         </repository>
     </repositories>
 
@@ -82,7 +82,7 @@
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-core</artifactId>
             <version>${jenkins.version}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -121,7 +121,7 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>${jenkins.servlet.version}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/io/stenic/jpipe/plugin/SkipCommitPlugin.groovy
+++ b/src/io/stenic/jpipe/plugin/SkipCommitPlugin.groovy
@@ -3,7 +3,6 @@ package io.stenic.jpipe.plugin
 import io.stenic.jpipe.event.Event
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
-import jenkins.model.CauseOfInterruption.UserInterruption
 import hudson.model.Result
 
 class SkipCommitPlugin extends Plugin {
@@ -43,7 +42,14 @@ class SkipCommitPlugin extends Plugin {
             //     event.script.currentBuild.getRawBuild().setResult(Result.fromString(event.script.currentBuild.getPreviousBuild().result))
             // } catch (RejectedAccessException e) {}
 
-            throw new FlowInterruptedException(Result.fromString(event.script.currentBuild.getPreviousBuild().result), true, new UserInterruption(event.script.env.BUILD_USER_ID))
+            // Do not attach a UserInterruption cause: [skip ci] builds are SCM-triggered,
+            // so BUILD_USER_ID is null. UserInterruption stores the null user id and its
+            // hashCode() NPEs inside FlowInterruptedException.handle() during
+            // WorkflowRun.finish(), which aborts completion before
+            // RunListener.fireCompleted() runs. That skips the GitHub Branch Source
+            // final commit status, leaving the commit stuck on "pending".
+            // actualInterruption is false because nobody actually interrupted the build.
+            throw new FlowInterruptedException(Result.fromString(event.script.currentBuild.getPreviousBuild()?.result ?: 'SUCCESS'), false)
         }
 
         return true


### PR DESCRIPTION
## Summary
- `[skip ci]` builds are SCM-triggered, so `env.BUILD_USER_ID` is null. `UserInterruption` stores that null user id and its `hashCode()` NPEs inside `FlowInterruptedException.handle()` during `WorkflowRun.finish()`, aborting completion before `RunListener.fireCompleted()` runs. As a result the GitHub Branch Source plugin never posts the final commit status and `[skip ci]` commits stay stuck on "pending".
- Throw the `FlowInterruptedException` without a cause and with `actualInterruption: false`, and guard against a missing previous build.
- Repair the maven test setup (https repo URL, `provided` scope for jenkins-core/servlet-api) so `make test` compiles and runs again.

## Testing
- `make test`: 12 tests run, 11 pass. The one failure (`basePipelineSpec`) is pre-existing and unrelated — it fails identically with the unmodified plugin code.