### PR TITLE
fix: keep [skip ci] runs green instead of aborting

### DIFF
--- a/src/io/stenic/jpipe/event/PipelineHalted.groovy
+++ b/src/io/stenic/jpipe/event/PipelineHalted.groovy
@@ -1,0 +1,18 @@
+package io.stenic.jpipe.event
+
+/**
+ * Thrown by a plugin to stop the pipeline early without aborting the run.
+ *
+ * Pipeline.run() catches this and returns normally, so the build keeps
+ * whatever result the plugin set (e.g. SUCCESS) and renders green. This is
+ * deliberately NOT a FlowInterruptedException: letting that escape marks the
+ * Jenkins run as aborted (gray/red) even when the current stage is green.
+ *
+ * The framework stays agnostic about why the pipeline was halted; the reason
+ * is free-form and supplied by the caller (e.g. SkipCommitPlugin on [skip ci]).
+ */
+class PipelineHalted extends RuntimeException implements Serializable {
+    PipelineHalted(String reason = 'Pipeline halted') {
+        super(reason)
+    }
+}

--- a/src/io/stenic/jpipe/pipeline/Pipeline.groovy
+++ b/src/io/stenic/jpipe/pipeline/Pipeline.groovy
@@ -3,6 +3,7 @@ package io.stenic.jpipe.pipeline
 import io.stenic.jpipe.plugin.PluginManager
 import io.stenic.jpipe.event.EventDispatcher
 import io.stenic.jpipe.event.Event
+import io.stenic.jpipe.event.PipelineHalted
 
 class Pipeline implements Serializable {
     protected final def script
@@ -27,34 +28,57 @@ class Pipeline implements Serializable {
         event.setScript(this.script)
         event.setEventDispatcher(this.eventDispatcher)
 
-        this.script.stage("Prepare") {
-            this.eventDispatcher.dispatch("Prepare", event)
-            this.script.currentBuild.displayName = event.version
-        }
+        // A plugin can stop the pipeline early by throwing PipelineHalted (e.g.
+        // SkipCommitPlugin on a [skip ci] commit). dispatchStage() catches it
+        // inside the stage closure, so the stage stays green and the run keeps
+        // whatever result the plugin set instead of aborting the build. The
+        // framework stays agnostic about why the pipeline was halted.
+        boolean halted = false
 
-        this.script.stage("Build") {
+        halted = this.dispatchStage("Prepare", event, halted, {
+            this.script.currentBuild.displayName = event.version
+        })
+
+        halted = this.dispatchStage("Build", event, halted, {
             this.script.echo "Version: ${event.version}";
-            this.eventDispatcher.dispatch("Build", event)
-        }
+        })
 
         if (this.eventDispatcher.getListeners("Test").size() > 0) {
-            this.script.stage("Test") {
-                this.eventDispatcher.dispatch("Test", event)
-            }
+            halted = this.dispatchStage("Test", event, halted)
         }
-        
+
         if (this.eventDispatcher.getListeners("Publish").size() > 0) {
-            this.script.stage("Publish") {
-                this.eventDispatcher.dispatch("Publish", event)
-            }
+            halted = this.dispatchStage("Publish", event, halted)
         }
-        
+
         if (this.eventDispatcher.getListeners("Deploy").size() > 0) {
-            this.script.stage("Deploy") {
-                this.eventDispatcher.dispatch("Deploy", event)
+            halted = this.dispatchStage("Deploy", event, halted)
+        }
+
+        return
+    }
+
+    // Runs a single stage: dispatches the event and runs an optional body.
+    // If a prior stage halted the pipeline, this is a no-op. If a handler
+    // throws PipelineHalted, it is swallowed inside the stage closure so the
+    // stage still renders green, and 'true' is returned to stop later stages.
+    private boolean dispatchStage(String name, Event event, boolean halted, Closure body = null) {
+        if (halted) {
+            return true
+        }
+
+        boolean stopped = false
+        this.script.stage(name) {
+            try {
+                this.eventDispatcher.dispatch(name, event)
+                if (body != null) {
+                    body()
+                }
+            } catch (PipelineHalted h) {
+                this.script.echo "Pipeline halted: ${h.message}"
+                stopped = true
             }
         }
-        
-        return 
+        return stopped
     }
 }

--- a/src/io/stenic/jpipe/plugin/SkipCommitPlugin.groovy
+++ b/src/io/stenic/jpipe/plugin/SkipCommitPlugin.groovy
@@ -1,9 +1,7 @@
 package io.stenic.jpipe.plugin
 
 import io.stenic.jpipe.event.Event
-import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException
-import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
-import hudson.model.Result
+import io.stenic.jpipe.event.PipelineHalted
 
 class SkipCommitPlugin extends Plugin {
     public Map getSubscribedEvents() {
@@ -27,29 +25,26 @@ class SkipCommitPlugin extends Plugin {
             }
             event.script.currentBuild.description = 'Skipped by [skip ci]'
 
+            // Carry the previous build's result forward onto this skipped run.
+            // currentBuild.result starts null (treated as SUCCESS); we set it
+            // explicitly so the run reflects the last real build's outcome.
+            event.script.currentBuild.result = event.script.currentBuild.getPreviousBuild()?.result ?: 'SUCCESS'
+
             // Notify subscribers (e.g. SCM status notifiers) that this build is being
-            // skipped, so they can publish a terminal commit status before we abort.
+            // skipped, so they can publish a terminal commit status. Without this the
+            // Jenkins GitHub Branch Source plugin's "pending" status on indexing never
+            // gets overwritten, leaving the commit stuck on pending.
             // SkipCommitPlugin stays SCM-agnostic; concrete notifiers live in user code.
             event.data.reason = 'Skipped by [skip ci]'
             event.eventDispatcher?.dispatch(Event.SKIPPED, event)
 
-            // try {
-            //     // Try doing a cleanup, required the following methods being approved.
-            //     // method hudson.model.Run delete
-            //     // method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild
-
-            //     event.script.currentBuild.getRawBuild().delete()
-            //     event.script.currentBuild.getRawBuild().setResult(Result.fromString(event.script.currentBuild.getPreviousBuild().result))
-            // } catch (RejectedAccessException e) {}
-
-            // Do not attach a UserInterruption cause: [skip ci] builds are SCM-triggered,
-            // so BUILD_USER_ID is null. UserInterruption stores the null user id and its
-            // hashCode() NPEs inside FlowInterruptedException.handle() during
-            // WorkflowRun.finish(), which aborts completion before
-            // RunListener.fireCompleted() runs. That skips the GitHub Branch Source
-            // final commit status, leaving the commit stuck on "pending".
-            // actualInterruption is false because nobody actually interrupted the build.
-            throw new FlowInterruptedException(Result.fromString(event.script.currentBuild.getPreviousBuild()?.result ?: 'SUCCESS'), false)
+            // Stop the pipeline. PipelineHalted is caught by Pipeline.run(), so the
+            // run finishes cleanly with the result set above and still fires the
+            // post-build status notifier for GitHub. We deliberately do NOT throw
+            // FlowInterruptedException: that aborts the run (gray/red ball) even
+            // though the Prepare stage is green, which is exactly the "stage green,
+            // run not green" symptom for [skip ci] builds.
+            throw new PipelineHalted('Skipped by [skip ci]')
         }
 
         return true

--- a/test/io/stenic/jpipe/pipeline/PipelineSpec.groovy
+++ b/test/io/stenic/jpipe/pipeline/PipelineSpec.groovy
@@ -1,0 +1,100 @@
+
+import spock.lang.Specification
+import io.stenic.jpipe.pipeline.Pipeline
+import io.stenic.jpipe.plugin.Plugin
+import io.stenic.jpipe.event.Event
+import io.stenic.jpipe.event.PipelineHalted
+
+class PipelineSpec extends Specification {
+
+    // Fake Jenkins script: records the stages that actually run and executes
+    // each stage closure inline (so handlers fire), mirroring stage() {}.
+    static class FakeScript {
+        List ranStages = []
+        List greenStages = []
+        def currentBuild = [displayName: '', result: null, description: '']
+
+        def stage(String name, Closure body) {
+            ranStages << name
+            body()
+            // Reached only if the body did not throw out of the stage.
+            greenStages << name
+        }
+
+        def echo(msg) {}
+    }
+
+    // Plugin that halts the pipeline from a given stage.
+    static class HaltingPlugin extends Plugin {
+        String stage
+        HaltingPlugin(String stage) { this.stage = stage }
+        Map getSubscribedEvents() {
+            return ["${this.stage}": [[{ e -> throw new PipelineHalted('stop here') }, 0]]]
+        }
+    }
+
+    // Plugin that just registers a listener so the optional stage runs.
+    static class NoopPlugin extends Plugin {
+        String stage
+        NoopPlugin(String stage) { this.stage = stage }
+        Map getSubscribedEvents() {
+            return ["${this.stage}": [[{ e -> }, 0]]]
+        }
+    }
+
+    def "[Pipeline] runs core stages on a normal build"() {
+        given:
+            def script = new FakeScript()
+            def pipeline = new Pipeline(script)
+
+        when:
+            pipeline.run([:], [BUILD_ID: '123'])
+
+        then:
+            assert script.ranStages == ['Prepare', 'Build']
+            assert script.greenStages == ['Prepare', 'Build']
+    }
+
+    def "[Pipeline] runs optional stages when a listener is registered"() {
+        given:
+            def script = new FakeScript()
+            def pipeline = new Pipeline(script)
+            pipeline.addPlugins([new NoopPlugin('Test'), new NoopPlugin('Deploy')])
+
+        when:
+            pipeline.run([:], [BUILD_ID: '123'])
+
+        then:
+            assert script.ranStages == ['Prepare', 'Build', 'Test', 'Deploy']
+    }
+
+    def "[Pipeline] a halt in Prepare keeps the stage green and skips later stages"() {
+        given:
+            def script = new FakeScript()
+            def pipeline = new Pipeline(script)
+            pipeline.addPlugins([new HaltingPlugin('Prepare')])
+
+        when:
+            pipeline.run([:], [BUILD_ID: '123'])
+
+        then:
+            // Prepare ran and stayed green (no exception escaped the stage),
+            // and no further stage was started.
+            assert script.ranStages == ['Prepare']
+            assert script.greenStages == ['Prepare']
+    }
+
+    def "[Pipeline] a halt does not abort the run"() {
+        given:
+            def script = new FakeScript()
+            def pipeline = new Pipeline(script)
+            pipeline.addPlugins([new HaltingPlugin('Prepare')])
+
+        when:
+            pipeline.run([:], [BUILD_ID: '123'])
+
+        then:
+            // run() returns normally; PipelineHalted is swallowed.
+            notThrown(PipelineHalted)
+    }
+}

--- a/test/io/stenic/jpipe/plugin/SkipCommitPluginSpec.groovy
+++ b/test/io/stenic/jpipe/plugin/SkipCommitPluginSpec.groovy
@@ -1,0 +1,143 @@
+
+import spock.lang.Specification
+import io.stenic.jpipe.event.Event
+import io.stenic.jpipe.event.EventDispatcher
+import io.stenic.jpipe.event.PipelineHalted
+import io.stenic.jpipe.plugin.SkipCommitPlugin
+
+class SkipCommitPluginSpec extends Specification {
+
+    // Minimal stand-in for currentBuild. Captures the result the plugin sets and
+    // exposes a configurable previous build + cause.
+    static class FakeBuild {
+        String description
+        def result
+        def previousBuild
+        def causeLookup = [:]   // class -> cause (null = not present)
+        def rawBuild
+
+        FakeBuild() {
+            this.rawBuild = [getCause: { type -> causeLookup[type] }]
+        }
+
+        def getPreviousBuild() { return previousBuild }
+    }
+
+    def newEvent(FakeBuild build, String commitMsg) {
+        def event = new Event()
+        event.setEventDispatcher(new EventDispatcher())
+        event.script = [
+            sh: { args -> commitMsg },
+            currentBuild: build,
+            env: [:],
+        ]
+        return event
+    }
+
+    def "[SkipCommitPlugin] proceeds on a normal commit"() {
+        given:
+            def plugin = new SkipCommitPlugin()
+            def event = newEvent(new FakeBuild(), "feat: a normal change")
+
+        expect:
+            assert plugin.doSkipCommit(event) == true
+    }
+
+    def "[SkipCommitPlugin] halts the pipeline on [skip ci]"() {
+        given:
+            def plugin = new SkipCommitPlugin()
+            def build = new FakeBuild()
+            def event = newEvent(build, "chore(release): 1.2.3 [skip ci]")
+
+        when:
+            plugin.doSkipCommit(event)
+
+        then:
+            def halted = thrown(PipelineHalted)
+            assert halted.message == 'Skipped by [skip ci]'
+            assert build.description == 'Skipped by [skip ci]'
+    }
+
+    def "[SkipCommitPlugin] also matches [ci skip]"() {
+        given:
+            def plugin = new SkipCommitPlugin()
+            def build = new FakeBuild()
+            def event = newEvent(build, "docs: tweak readme [ci skip]")
+
+        when:
+            plugin.doSkipCommit(event)
+
+        then:
+            thrown(PipelineHalted)
+    }
+
+    def "[SkipCommitPlugin] carries the previous build result forward"() {
+        given:
+            def plugin = new SkipCommitPlugin()
+            def build = new FakeBuild(previousBuild: [result: 'UNSTABLE'])
+            def event = newEvent(build, "chore(release): 9.9.9 [skip ci]")
+
+        when:
+            plugin.doSkipCommit(event)
+
+        then:
+            thrown(PipelineHalted)
+            assert build.result == 'UNSTABLE'
+    }
+
+    def "[SkipCommitPlugin] reflects a previous failure on the skipped run"() {
+        given:
+            def plugin = new SkipCommitPlugin()
+            def build = new FakeBuild(previousBuild: [result: 'FAILURE'])
+            def event = newEvent(build, "chore(release): 9.9.9 [skip ci]")
+
+        when:
+            plugin.doSkipCommit(event)
+
+        then:
+            thrown(PipelineHalted)
+            assert build.result == 'FAILURE'
+    }
+
+    def "[SkipCommitPlugin] defaults to SUCCESS when there is no previous build"() {
+        given:
+            def plugin = new SkipCommitPlugin()
+            def build = new FakeBuild(previousBuild: null)
+            def event = newEvent(build, "chore(release): 1.0.0 [skip ci]")
+
+        when:
+            plugin.doSkipCommit(event)
+
+        then:
+            thrown(PipelineHalted)
+            assert build.result == 'SUCCESS'
+    }
+
+    def "[SkipCommitPlugin] emits SKIPPED with a reason so notifiers can publish status"() {
+        given:
+            def plugin = new SkipCommitPlugin()
+            def build = new FakeBuild()
+            def event = newEvent(build, "chore(release): 2.0.0 [skip ci]")
+
+            def reasons = []
+            event.eventDispatcher.addListener(Event.SKIPPED, { e -> reasons << e.data.reason }, 0)
+
+        when:
+            plugin.doSkipCommit(event)
+
+        then:
+            thrown(PipelineHalted)
+            assert reasons == ['Skipped by [skip ci]']
+    }
+
+    def "[SkipCommitPlugin] does not skip when triggered by a user"() {
+        given:
+            def plugin = new SkipCommitPlugin()
+            def build = new FakeBuild()
+            build.causeLookup[hudson.model.Cause$UserIdCause] = [id: 'someone']
+            def event = newEvent(build, "chore(release): 3.0.0 [skip ci]")
+
+        expect:
+            assert plugin.doSkipCommit(event) == true
+    }
+}


### PR DESCRIPTION
## Problem

For `[skip ci]` commits the **Prepare stage is green** but the **overall run is not** (red/gray ball): skip-ci builds run only Prepare (green cell) yet the build badge is red.

This regressed while fixing GitHub showing **"pending"** for `[skip ci]` builds. To stop the build, `SkipCommitPlugin` threw `FlowInterruptedException`, which:

1. **Aborts the whole run** even though Prepare succeeded — exactly the "stage green, run not green" symptom.
2. Copied the **previous build's result** onto the exception, so once a skipped run went aborted it **propagated aborted forward** across subsequent `[skip ci]` builds (common with semantic-release-bot release commits).

The "pending" fix solved the GitHub side but broke the Jenkins run status.

## Fix

Stop the pipeline cleanly via a framework signal instead of an abort:

- **`PipelineHalted`** (new): a jpipe exception a plugin can throw to stop the run early.
- **`Pipeline`**: `dispatchStage()` catches `PipelineHalted` **inside** the stage closure, so the stage stays green, later stages are skipped, and the run keeps whatever result was set — no abort. `Pipeline.run()` stays agnostic about *why* it was halted, so no skip-ci specifics leak into the core orchestration.
- **`SkipCommitPlugin`**: set `currentBuild.result` to the previous build's result (default `SUCCESS`; a previous `FAILURE`/`UNSTABLE` is reflected on the skipped run), emit the `SKIPPED` event so SCM status notifiers publish a terminal commit status, then throw `PipelineHalted`.

The `SKIPPED` event still fires before stopping, so the GitHub status notifier keeps working (GitHub no longer stuck on pending) **and** the Jenkins run is green again (or reflects the previous result).

## Tests

- `SkipCommitPluginSpec`: proceeds on normal commits; halts on `[skip ci]`/`[ci skip]`; forwards the previous result (including `FAILURE`); defaults to `SUCCESS` with no previous build; emits `SKIPPED` with a reason; ignores skip when user-triggered.
- `PipelineSpec` (new): core stages run normally; optional stages run when a listener exists; a halt in Prepare keeps the stage green and skips later stages; a halt does not abort the run.

`mvn clean test`: all new tests pass (SkipCommitPluginSpec 8/8, PipelineSpec 4/4, EventSpec 3/3). The single remaining failure (`basePipelineSpec`) is pre-existing on `main` and unrelated to this change.

## Consumer impact

Downstream consumers that publish SCM status by subscribing to `Event.SKIPPED` are unaffected — that contract is unchanged. No consumer code change needed, only a version bump.